### PR TITLE
Add include vector statement

### DIFF
--- a/headers/hdhomerun_wrapper.h
+++ b/headers/hdhomerun_wrapper.h
@@ -4,6 +4,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
+#include <vector>
 #include <libhdhomerun/hdhomerun.h>
 #include "channel.h"
 


### PR DESCRIPTION
This tweak was made due to an issue faced on Ubuntu 20.04 from a lack of using `#include <vector>`